### PR TITLE
Update doc to use "term" instead of "terminal"

### DIFF
--- a/term.go
+++ b/term.go
@@ -7,11 +7,11 @@
 //
 // Putting a terminal into raw mode is the most common requirement:
 //
-// 	oldState, err := terminal.MakeRaw(0)
+// 	oldState, err := term.MakeRaw(0)
 // 	if err != nil {
 // 	        panic(err)
 // 	}
-// 	defer terminal.Restore(0, oldState)
+// 	defer term.Restore(0, oldState)
 package term
 
 // State contains the state of a terminal.


### PR DESCRIPTION
Very small patch, but the example at the top still used the old
"terminal" package name, resulting in "golang.org/x/crypto/ssh/terminal"
being goimport'd instead of golang.org/x/term