### PR TITLE
term: add support to catch keys directly when entered

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -110,6 +110,7 @@ type Terminal struct {
 func NewTerminal(c io.ReadWriter, prompt string) *Terminal {
 	return &Terminal{
 		Escape:       &vt100EscapeCodes,
+		OnKey:        map[rune]func(key rune) (resume bool){},
 		c:            c,
 		prompt:       []rune(prompt),
 		termWidth:    80,

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -273,7 +273,7 @@ var onKeyTests = []struct {
 		out: "a",
 	},
 	{
-		// catch Ctrl-D but terminate with Ctrl-C
+		// Catch Ctrl-D but terminate with Ctrl-C
 		in: "\004\r",
 		onKey: map[rune]func(key rune) bool{keyCtrlC: func(key rune) bool {
 			return false
@@ -281,12 +281,20 @@ var onKeyTests = []struct {
 		err: io.EOF,
 	},
 	{
-		// catch Ctrl-D but resume (expressed with the positive return)
+		// Catch Ctrl-D but resume (expressed with the positive return)
 		in: "\004\r",
 		onKey: map[rune]func(key rune) bool{keyCtrlD: func(key rune) bool {
 			return true
 		}},
 		err: io.EOF,
+	},
+	{
+		// Catch the character 'e' and prevent it (with the false return) to be processed
+		in: "test\r",
+		onKey: map[rune]func(key rune) bool{'e': func(key rune) bool {
+			return false
+		}},
+		out: "tst",
 	},
 }
 


### PR DESCRIPTION
Adds functionality to catch keys / characters right after the terminal receives them.
This is very helpful when you want to handle, for example, special key combinations like Ctrl-C yourself and not just let them terminate your terminal without anything you can do about it.

To receive this, a new `OnKey` field was added to the terminal struct.
```go
type Terminal struct {
    ...
    OnKey map[rune]func(key rune) (resume bool)
    ...
}
```

The map stores pairs of runes (which represents a keycode) and functions. Whenever a key is entered and the keycode of it exists in this map the corresponding functions gets called. The function takes the key as its only argument and returns if the normal behaviour of the key, if existent, should continue. This behaviour could be the termination of the terminal (if the key was Ctrl-C) or just a normal letter.