### PR TITLE
term: consistently return zeroes on GetSize error

### DIFF
--- a/term_unix.go
+++ b/term_unix.go
@@ -60,7 +60,7 @@ func restore(fd int, state *State) error {
 func getSize(fd int) (width, height int, err error) {
 	ws, err := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ)
 	if err != nil {
-		return -1, -1, err
+		return 0, 0, err
 	}
 	return int(ws.Col), int(ws.Row), nil
 }


### PR DESCRIPTION
All other platform have return value of 0 for error when trying to get
the terminal size while unix have -1. That makes it hard to catch
whether the value passed from it was inserted on purpose.