### PR TITLE
Add aliases for alt-right, alt-left and alt-delete

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -181,6 +181,17 @@ func bytesToKey(b []byte, pasteActive bool) (rune, []byte) {
 		return r, b[l:]
 	}
 
+	if !pasteActive && len(b) >= 2 && b[0] == keyEscape {
+		switch b[1] {
+		case 'b':
+			return keyAltLeft, b[2:]
+		case 'f':
+			return keyAltRight, b[2:]
+		case 127:
+			return keyDeleteWord, b[2:]
+		}
+	}
+
 	if !pasteActive && len(b) >= 3 && b[0] == keyEscape && b[1] == '[' {
 		switch b[2] {
 		case 'A':

--- a/terminal.go
+++ b/terminal.go
@@ -181,7 +181,9 @@ func bytesToKey(b []byte, pasteActive bool) (rune, []byte) {
 		return r, b[l:]
 	}
 
-	if !pasteActive && len(b) >= 2 && b[0] == keyEscape {
+	// b[0] == keyEscape from now on
+
+	if !pasteActive && len(b) >= 2 {
 		switch b[1] {
 		case 'b':
 			return keyAltLeft, b[2:]
@@ -192,7 +194,7 @@ func bytesToKey(b []byte, pasteActive bool) (rune, []byte) {
 		}
 	}
 
-	if !pasteActive && len(b) >= 3 && b[0] == keyEscape && b[1] == '[' {
+	if !pasteActive && len(b) >= 3 && b[1] == '[' {
 		switch b[2] {
 		case 'A':
 			return keyUp, b[3:]
@@ -209,7 +211,7 @@ func bytesToKey(b []byte, pasteActive bool) (rune, []byte) {
 		}
 	}
 
-	if !pasteActive && len(b) >= 6 && b[0] == keyEscape && b[1] == '[' && b[2] == '1' && b[3] == ';' && b[4] == '3' {
+	if !pasteActive && len(b) >= 6 && b[1] == '[' && b[2] == '1' && b[3] == ';' && b[4] == '3' {
 		switch b[5] {
 		case 'C':
 			return keyAltRight, b[6:]


### PR DESCRIPTION
I noticed that <kbd>option</kbd>+<kbd>→</kbd> (move right by word), <kbd>option</kbd>+<kbd>←</kbd> (move left by word) and <kbd>option</kbd>+<kbd>delete</kbd> (delete by word) weren't working, at least on macOS. Used raw mode and some debugging to figure out what escape codes were being signaled.

This PR also removes two unnecessary checks for whether the first byte is the escape character. (Unnecessary because the function returns earlier if the first byte _isn't_ the escape character) 

Sample program to see the change this PR makes:
Run this and then compare how alt-right, alt-left and alt-delete work with this change and without.
```go
package main

import (
	"fmt"
	"os"

	"golang.org/x/term"
)

func main() {
	fmt.Println("Use q to quit")
	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
	if err != nil {
		panic(err)
	}
	defer term.Restore(int(os.Stdin.Fd()), oldState)

	t := term.NewTerminal(os.Stdin, "> ")
	for {
		line, err := t.ReadLine()
		if err != nil {
			fmt.Println(err)
			break
		}
		if line == "q" {
			break
		}
		t.Write([]byte(line + "\n"))
	}
}
```