### PR TITLE
x/term: prevent invalid indexing into stRingBuffer

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -935,7 +935,7 @@ func (s *stRingBuffer) Add(a string) {
 // next most recent, and so on. If such an element doesn't exist then ok is
 // false.
 func (s *stRingBuffer) NthPreviousEntry(n int) (value string, ok bool) {
-	if n >= s.size {
+	if n < 0 || n >= s.size {
 		return "", false
 	}
 	index := s.head - n


### PR DESCRIPTION
The exported method (*stRingBuffer).NthPreviousEntry does not correctly
handle arguments with negative values. A negative value will index
beyond slice boundaries in most cases (unless size = max = INT_MAX) and
cause an access violation at runtime.

This change adds a condition to return ok = false for all negatively
valued arguments, which is the same behavior that occurs with positively
valued arguments exceeding buffer length.

Adding the capability to index backwards (from the end of the slice)
does not seem like the intent of this method, and it would not improve
or simplify existing functionality. It would also be inconsistent with
the handling of positive values out-of-bounds.