### PR TITLE
term: remove unused variable

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -233,7 +233,6 @@ func (t *Terminal) queue(data []rune) {
 	t.outBuf = append(t.outBuf, []byte(string(data))...)
 }
 
-var eraseUnderCursor = []rune{' ', keyEscape, '[', 'D'}
 var space = []rune{' '}
 
 func isPrintable(key rune) bool {


### PR DESCRIPTION
The eraseUnderCursor variable is unused, it came in with the import
of the x/crypto/ssh/terminal package at d7a7210 but is not referenced
here.

When this package is vendored, the unused unexported name trips warnings 
from tools like staticcheck.