### PR TITLE
term: remove duplicate flag and add comment on windows

### DIFF
--- a/term_windows.go
+++ b/term_windows.go
@@ -20,12 +20,14 @@ func isTerminal(fd int) bool {
 	return err == nil
 }
 
+// XXX: This is intended to be used on a console input handle.
+// See https://learn.microsoft.com/en-us/windows/console/setconsolemode
 func makeRaw(fd int) (*State, error) {
 	var st uint32
 	if err := windows.GetConsoleMode(windows.Handle(fd), &st); err != nil {
 		return nil, err
 	}
-	raw := st &^ (windows.ENABLE_ECHO_INPUT | windows.ENABLE_PROCESSED_INPUT | windows.ENABLE_LINE_INPUT | windows.ENABLE_PROCESSED_OUTPUT)
+	raw := st &^ (windows.ENABLE_ECHO_INPUT | windows.ENABLE_PROCESSED_INPUT | windows.ENABLE_LINE_INPUT)
 	if err := windows.SetConsoleMode(windows.Handle(fd), raw); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Both `windows.ENABLE_PROCESSED_INPUT` and `windows.ENABLE_PROCESSED_OUTPUT` have the same value of `0x1`. Using `makeRaw` on a console output screen buffer handle wouldn't make sense since on Windows the input handle and the output screen buffer handle are two separate things.

See https://learn.microsoft.com/en-us/windows/console/setconsolemode