### PR TITLE
x/term: add history APIs.

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -980,7 +980,8 @@ func NewHistory(capacity int) *stRingBuffer {
 }
 
 // DefaultHistoryEntries is the default number of entries in the history.
-const DefaultHistoryEntries = 100
+// History index 1-99 prints using %02d.
+const DefaultHistoryEntries = 99
 
 func (s *stRingBuffer) Add(a string) {
 	if s.entries[s.head] == a {

--- a/terminal.go
+++ b/terminal.go
@@ -844,7 +844,7 @@ func (t *Terminal) AutoHistory(onOff bool) {
 	t.lock.Unlock()
 }
 
-// ReplaceLast replaces the most recent history entry with the given string.
+// ReplaceLatest replaces the most recent history entry with the given string.
 // Enables to add invalid commands to the history for editing purpose and
 // replace them with the corrected version. Returns the replaced entry.
 func (t *Terminal) ReplaceLatest(entry string) string {

--- a/terminal.go
+++ b/terminal.go
@@ -961,7 +961,9 @@ func (s *stRingBuffer) Add(a string) {
 		s.entries = make([]string, defaultNumEntries)
 		s.max = defaultNumEntries
 	}
-
+	if s.entries[s.head] == a {
+		return // already there at the top
+	}
 	s.head = (s.head + 1) % s.max
 	s.entries[s.head] = a
 	if s.size < s.max {

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -462,4 +462,9 @@ func TestHistoryNoDuplicates(t *testing.T) {
 	if !reflect.DeepEqual(h, []string{"c", "b", "a"}) {
 		t.Errorf("history unexpected: %v", h)
 	}
+	ss.ReplaceLatest("x")
+	h = ss.History()
+	if !reflect.DeepEqual(h, []string{"x", "b", "a"}) {
+		t.Errorf("history unexpected: %v", h)
+	}
 }


### PR DESCRIPTION
In order for users of the library to save and restore the history, expose:

- `History() []string`: returns a slice of strings containing the history of entered commands so far.
- `AddToHistory(cmd ...string)`: populates history.
- `NewHistory(capacity int)`: resets the history to a new one of the given capacity.
- `AutoHistory(bool)` sets whether lines are automatically added to the history (defaults remains true).
- `ReplaceLatest(entry string) string` replaces the most recent entry (useful for correcting invalid commands).

- Also avoid adding adjacent exact duplicates to the history (consuming slots unnecessarily)
- Added a test, more comments, and expose the `100` default history constant.

Demonstration of use https://github.com/fortio/terminal/commit/77eee7bf6d25ac9323fccdf2c2c6e1dcb6acebe2

Fixes golang/go#68780
