### PR TITLE
x/term: set missing VIRTUAL_TERMINAL_INPUT flag on Windows

### DIFF
--- a/term_windows.go
+++ b/term_windows.go
@@ -26,6 +26,7 @@ func makeRaw(fd int) (*State, error) {
 		return nil, err
 	}
 	raw := st &^ (windows.ENABLE_ECHO_INPUT | windows.ENABLE_PROCESSED_INPUT | windows.ENABLE_LINE_INPUT | windows.ENABLE_PROCESSED_OUTPUT)
+	raw |= windows.ENABLE_VIRTUAL_TERMINAL_INPUT
 	if err := windows.SetConsoleMode(windows.Handle(fd), raw); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
With this change the arrow keys work with Windows 11 Terminal

After verifying https://github.com/containerd/console did work fine, unlike x/term, it's because they have:
https://github.com/containerd/console/blob/v1.0.4/console_windows.go#L194
using the same flag fixed x/term for my program

Small e2e test reproducing the issue and showing it being fixed can be ran using

go run fortio.org/terminal/example@v0.6.0  # has the fix (or @latest)

go run fortio.org/terminal/example@v0.5.1  -history .history # does not have working arrow keys/this fix

Fixes golang/go#68830
