### PR TITLE
term: support pluggable history

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -950,7 +950,7 @@ func (s *stRingBuffer) Add(a string) {
 	}
 }
 
-// NthPreviousEntry returns the value passed to the nth previous call to Add.
+// At returns the value passed to the nth previous call to Add.
 // If n is zero then the immediately prior value is returned, if one, then the
 // next most recent, and so on. If such an element doesn't exist then ok is
 // false.

--- a/terminal.go
+++ b/terminal.go
@@ -793,7 +793,9 @@ func (t *Terminal) readLine() (line string, err error) {
 		if lineOk {
 			if t.echo {
 				t.historyIndex = -1
-				t.History.Add(line)
+				t.lock.Unlock()
+				t.History.Add(line) // so this can output without deadlock.
+				t.lock.Lock()
 			}
 			if lineIsPasted {
 				err = ErrPasteIndicator

--- a/terminal.go
+++ b/terminal.go
@@ -36,13 +36,18 @@ var vt100EscapeCodes = EscapeCodes{
 	Reset: []byte{keyEscape, '[', '0', 'm'},
 }
 
+// The History interface provides a way to replace the default automatic
+// 100 slots ringbuffer implementation.
 type History interface {
-	// adds a new line into the history
-	Add(string)
+	// Add will be called by Terminal to add a new line into the history.
+	// An implementation may decide to not add every lines by ignoring calls
+	// to this function (from Terminal.ReadLine) and to only add validated
+	// entries out of band.
+	Add(entry string)
 
-	// retrieves a line from history
-	// 0 should be the most recent entry
-	// ok = false when out of range
+	// At retrieves a line from history.
+	// idx 0 should be the most recent entry.
+	// return false when out of range.
 	At(idx int) (string, bool)
 }
 
@@ -99,6 +104,7 @@ type Terminal struct {
 	// History allows to replace the default implementation of the history
 	// which contains previously entered commands so that they can be
 	// accessed with the up and down keys.
+	// It's not safe to call ReadLine and methods on History concurrently.
 	History History
 	// historyIndex stores the currently accessed history entry, where zero
 	// means the immediately previous entry.

--- a/terminal.go
+++ b/terminal.go
@@ -38,10 +38,6 @@ var vt100EscapeCodes = EscapeCodes{
 }
 
 // A History provides a (possibly bounded) queue of input lines read by [Terminal.ReadLine].
-//
-// The default implementation of History provides a simple ring buffer limited
-// to 100 slots. Clients can provide alternate implementations of History to
-// change this behavior.
 type History interface {
 	// Add will be called by [Terminal.ReadLine] to add
 	// a new, most recent entry to the history.
@@ -116,7 +112,8 @@ type Terminal struct {
 	//
 	// It is not safe to call ReadLine concurrently with any methods on History.
 	//
-	// [NewTerminal] sets this to an implementation that records the last 100 lines of input.
+	// [NewTerminal] sets this to a default implementation that records the
+	// last 100 lines of input.
 	History History
 	// historyIndex stores the currently accessed history entry, where zero
 	// means the immediately previous entry.

--- a/terminal.go
+++ b/terminal.go
@@ -45,6 +45,9 @@ type History interface {
 	// entries out of band.
 	Add(entry string)
 
+	// Len returns the current number of entries in the history.
+	Len() int
+
 	// At retrieves a line from history.
 	// idx 0 should be the most recent entry.
 	// return false when out of range.
@@ -968,6 +971,10 @@ func (s *stRingBuffer) Add(a string) {
 	if s.size < s.max {
 		s.size++
 	}
+}
+
+func (s *stRingBuffer) Len() int {
+	return s.size
 }
 
 // At returns the value passed to the nth previous call to Add.

--- a/terminal.go
+++ b/terminal.go
@@ -43,7 +43,7 @@ var vt100EscapeCodes = EscapeCodes{
 // to 100 slots. Clients can provide alternate implementations of History to
 // change this behavior.
 type History interface {
-	// Add adds will be called by [Terminal.ReadLine] to add
+	// Add will be called by [Terminal.ReadLine] to add
 	// a new, most recent entry to the history.
 	// It is allowed to drop any entry, including
 	// the entry being added (e.g., if it's deemed an invalid entry),


### PR DESCRIPTION
Expose a new History interface that allows replacement of the default
ring buffer to customize what gets added or not; as well as to allow
saving/restoring history on either the default ringbuffer or a custom
replacement.

Fixes golang/go#68780